### PR TITLE
loop basis for multi design types

### DIFF
--- a/app/models/design-artboard.server.ts
+++ b/app/models/design-artboard.server.ts
@@ -2,7 +2,7 @@ import { type Design } from '@prisma/client'
 import { DesignTypeEnum, type designTypeEnum } from '#app/schema/design'
 import { prisma } from '#app/utils/db.server'
 import { filterVisibleDesigns, orderLinkedDesigns } from '#app/utils/design'
-import { filterDefinedRotates } from '#app/utils/rotate'
+import { filterNonArrayRotates } from '#app/utils/rotate'
 import { type IArtboard } from './artboard.server'
 import {
 	findManyDesignsWithType,
@@ -78,5 +78,7 @@ export const getArtboardVisibleRotates = async ({
 		orderLinkedDesigns(designRotates),
 	) as IDesignWithRotate[]
 
-	return filterDefinedRotates(visibleDesignRotates.map(design => design.rotate))
+	return filterNonArrayRotates(
+		visibleDesignRotates.map(design => design.rotate),
+	)
 }

--- a/app/models/design-layer.server.ts
+++ b/app/models/design-layer.server.ts
@@ -2,7 +2,7 @@ import { type Design } from '@prisma/client'
 import { DesignTypeEnum, type designTypeEnum } from '#app/schema/design'
 import { prisma } from '#app/utils/db.server'
 import { filterVisibleDesigns, orderLinkedDesigns } from '#app/utils/design'
-import { filterDefinedRotates } from '#app/utils/rotate'
+import { filterNonArrayRotates } from '#app/utils/rotate'
 import {
 	findManyDesignsWithType,
 	type IDesignWithPalette,
@@ -78,5 +78,7 @@ export const getLayerVisibleRotates = async ({
 		orderLinkedDesigns(designRotates),
 	) as IDesignWithRotate[]
 
-	return filterDefinedRotates(visibleDesignRotates.map(design => design.rotate))
+	return filterNonArrayRotates(
+		visibleDesignRotates.map(design => design.rotate),
+	)
 }

--- a/app/routes/sketch+/artboards+/$slug_+/components/panel/layer/design/panel-content-layer-design-line.tsx
+++ b/app/routes/sketch+/artboards+/$slug_+/components/panel/layer/design/panel-content-layer-design-line.tsx
@@ -29,7 +29,7 @@ import { PanelFormLayerDesignDelete } from '../../../forms/layer/design/panel-fo
 import { PanelFormLayerDesignNew } from '../../../forms/layer/design/panel-form-layer-design-new'
 import { PanelFormLayerDesignReorder } from '../../../forms/layer/design/panel-form-layer-design-reorder'
 import { PanelFormLayerDesignToggleVisibile } from '../../../forms/layer/design/panel-form-layer-design-toggle-visible'
-import { PanelPopoverDesignLine } from '../../../popovers/design/panel-popover-design-line'
+import { PanelDialogDesignLine } from '../../../popovers/design/panel-dialog-design-line'
 
 export const PanelContentLayerDesignLine = ({
 	layer,
@@ -136,7 +136,8 @@ export const PanelContentLayerDesignLine = ({
 						</PanelRowOrderContainer>
 						<PanelRowContainer>
 							<PanelRowValueContainer>
-								<PanelPopoverDesignLine line={line} />
+								{/* <PanelPopoverDesignLine line={line} /> */}
+								<PanelDialogDesignLine line={line} />
 								<PanelFormDesignLineEditWidth line={line} />
 								<LineFormatIcon />
 								<LineBasisIcon />

--- a/app/routes/sketch+/artboards+/$slug_+/components/panel/layer/design/panel-content-layer-design-rotate.tsx
+++ b/app/routes/sketch+/artboards+/$slug_+/components/panel/layer/design/panel-content-layer-design-rotate.tsx
@@ -23,7 +23,7 @@ import { PanelFormLayerDesignDelete } from '../../../forms/layer/design/panel-fo
 import { PanelFormLayerDesignNew } from '../../../forms/layer/design/panel-form-layer-design-new'
 import { PanelFormLayerDesignReorder } from '../../../forms/layer/design/panel-form-layer-design-reorder'
 import { PanelFormLayerDesignToggleVisibile } from '../../../forms/layer/design/panel-form-layer-design-toggle-visible'
-import { PanelPopoverDesignRotate } from '../../../popovers/design/panel-popover-design-rotate'
+import { PanelDialogDesignRotate } from '../../../popovers/design/panel-dialog-design-rotate'
 
 export const PanelContentLayerDesignRotate = ({
 	layer,
@@ -118,7 +118,12 @@ export const PanelContentLayerDesignRotate = ({
 						</PanelRowOrderContainer>
 						<PanelRowContainer>
 							<PanelRowValueContainer>
-								<PanelPopoverDesignRotate rotate={rotate} />
+								{/* popover unusable behavior when select triggered */}
+								{/* moves to top of page and prevents scroll  */}
+								{/* potential here: https://github.com/radix-ui/primitives/issues/2122 */}
+								{/* switching to dialog in the meantime as workaround */}
+								{/* <PanelPopoverDesignRotate rotate={rotate} /> */}
+								<PanelDialogDesignRotate rotate={rotate} />
 								{rotate.basis !== 'defined' ? (
 									<Input
 										type="text"

--- a/app/routes/sketch+/artboards+/$slug_+/components/popovers/design/panel-dialog-design-line.tsx
+++ b/app/routes/sketch+/artboards+/$slug_+/components/popovers/design/panel-dialog-design-line.tsx
@@ -1,0 +1,57 @@
+import { Button } from '#app/components/ui/button'
+import { Dialog, DialogContent, DialogTrigger } from '#app/components/ui/dialog'
+import { Icon } from '#app/components/ui/icon'
+import { Input } from '#app/components/ui/input'
+import { Label } from '#app/components/ui/label'
+import { type ILine } from '#app/models/line.server'
+import { PanelFormDesignLineEditBasis } from '../../forms/design/panel-form-design-line-edit-basis'
+import { PanelFormDesignLineEditFormat } from '../../forms/design/panel-form-design-line-edit-format'
+
+export const PanelDialogDesignLine = ({ line }: { line: ILine }) => {
+	return (
+		<div>
+			<Dialog modal={false}>
+				<DialogTrigger asChild>
+					<Button
+						variant="ghost"
+						size="sm"
+						className="m-2 mr-0 flex h-8 w-8 cursor-pointer items-center justify-center"
+					>
+						<Icon name="gear">
+							<span className="sr-only">Line Settings</span>
+						</Icon>
+					</Button>
+				</DialogTrigger>
+				<DialogContent className="w-80">
+					<div className="grid gap-4">
+						<div className="space-y-2">
+							<h4 className="font-medium leading-none">Line</h4>
+							<p className="text-sm text-muted-foreground">
+								Settings for this line.
+							</p>
+						</div>
+						<div className="grid gap-2">
+							<div className="grid grid-cols-3 items-center gap-4">
+								<Label htmlFor="width">Width</Label>
+								<Input
+									id="width"
+									defaultValue={line.width}
+									className="col-span-2 h-8"
+									disabled
+								/>
+							</div>
+							<div className="grid grid-cols-3 items-center gap-4">
+								<Label htmlFor="style">Format</Label>
+								<PanelFormDesignLineEditFormat line={line} />
+							</div>
+							<div className="grid grid-cols-3 items-center gap-4">
+								<Label htmlFor="style">Basis</Label>
+								<PanelFormDesignLineEditBasis line={line} />
+							</div>
+						</div>
+					</div>
+				</DialogContent>
+			</Dialog>
+		</div>
+	)
+}

--- a/app/routes/sketch+/artboards+/$slug_+/components/popovers/design/panel-dialog-design-rotate.tsx
+++ b/app/routes/sketch+/artboards+/$slug_+/components/popovers/design/panel-dialog-design-rotate.tsx
@@ -1,20 +1,16 @@
 import { Button } from '#app/components/ui/button'
+import { Dialog, DialogContent, DialogTrigger } from '#app/components/ui/dialog'
 import { Icon } from '#app/components/ui/icon'
 import { Input } from '#app/components/ui/input'
 import { Label } from '#app/components/ui/label'
-import {
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-} from '#app/components/ui/popover'
 import { type IRotate } from '#app/models/rotate.server'
 import { PanelFormDesignRotateEditBasis } from '../../forms/design/panel-form-design-rotate-edit-basis'
 
-export const PanelPopoverDesignRotate = ({ rotate }: { rotate: IRotate }) => {
+export const PanelDialogDesignRotate = ({ rotate }: { rotate: IRotate }) => {
 	return (
 		<div>
-			<Popover>
-				<PopoverTrigger asChild>
+			<Dialog modal={false}>
+				<DialogTrigger asChild>
 					<Button
 						variant="ghost"
 						size="sm"
@@ -24,19 +20,8 @@ export const PanelPopoverDesignRotate = ({ rotate }: { rotate: IRotate }) => {
 							<span className="sr-only">Rotate Settings</span>
 						</Icon>
 					</Button>
-				</PopoverTrigger>
-				<PopoverContent
-					className="PopoverContent w-80"
-					// when I open the select it scrolls to the top and prevents scroll
-					// so I can't make changes to select below the fold
-					// align="end"
-					// side="top"
-					// sideOffset={100}
-					// avoidCollisions={false}
-					// onPointerDownOutside={e => e.preventDefault()}
-					// onFocusOutside={e => e.preventDefault()}
-					// onInteractOutside={e => e.preventDefault()}
-				>
+				</DialogTrigger>
+				<DialogContent className="w-80">
 					<span tabIndex={0} className="sr-only" />
 					<div className="grid gap-4">
 						<div className="space-y-2">
@@ -61,8 +46,8 @@ export const PanelPopoverDesignRotate = ({ rotate }: { rotate: IRotate }) => {
 							</div>
 						</div>
 					</div>
-				</PopoverContent>
-			</Popover>
+				</DialogContent>
+			</Dialog>
 		</div>
 	)
 }

--- a/app/routes/sketch+/artboards+/$slug_+/services/artboard/build/create.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/artboard/build/create.service.ts
@@ -17,8 +17,9 @@ import { findRotateInDesignArray } from '#app/models/rotate.server'
 import { findSizeInDesignArray } from '#app/models/size.server'
 import { findStrokeInDesignArray } from '#app/models/stroke.server'
 import { findTemplateInDesignArray } from '#app/models/template.server'
-import { RotateBasisTypeEnum } from '#app/schema/rotate'
+import { type rotateBasisTypeEnum } from '#app/schema/rotate'
 import { filterLayersVisible } from '#app/utils/layer.utils'
+import { isArrayRotateBasisType } from '#app/utils/rotate'
 import {
 	type IArtboardLayerBuild,
 	type PickedArtboardType,
@@ -87,10 +88,9 @@ const getSelectedDesignsForArtboard = async ({
 
 	// get all visible rotates to use for rotate if defined random
 	// no defined random rotates and no rotates will default to 0 rotation
-	const rotates =
-		rotate.basis === RotateBasisTypeEnum.DEFINED_RANDOM
-			? await getArtboardVisibleRotates({ artboardId })
-			: []
+	const rotates = isArrayRotateBasisType(rotate.basis as rotateBasisTypeEnum)
+		? await getArtboardVisibleRotates({ artboardId })
+		: []
 
 	const { width, height } = artboard
 	const container = {
@@ -182,7 +182,7 @@ const getSelectedDesignTypesForLayer = async ({
 
 	// get all visible rotates to use for rotate
 	// if empty, then use the artboard rotate
-	if (rotate?.basis === RotateBasisTypeEnum.DEFINED_RANDOM) {
+	if (rotate && isArrayRotateBasisType(rotate.basis as rotateBasisTypeEnum)) {
 		const rotates = await getLayerVisibleRotates({ layerId })
 		if (rotates.length > 0) {
 			result.rotates = rotates

--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-fill.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-fill.service.ts
@@ -30,6 +30,10 @@ export const canvasBuildLayerDrawFillService = ({
 		case FillBasisTypeEnum.PALETTE_LOOP:
 			const paletteLoopIndex = index % palette.length
 			return palette[paletteLoopIndex].value
+		case FillBasisTypeEnum.PALETTE_LOOP_REVERSE:
+			const paletteReverseLoopIndex =
+				palette.length - 1 - (index % palette.length)
+			return palette[paletteReverseLoopIndex].value
 		case FillBasisTypeEnum.PIXEL:
 			// random to highlight something went wrong
 			return pixelHex || colorRandomHex()

--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-fill.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-fill.service.ts
@@ -25,8 +25,11 @@ export const canvasBuildLayerDrawFillService = ({
 		case FillBasisTypeEnum.PALETTE_SELECTED:
 			return palette[0].value
 		case FillBasisTypeEnum.PALETTE_RANDOM:
-			const index = randomIndex(palette)
-			return palette[index].value
+			const paletteRandomIndex = randomIndex(palette)
+			return palette[paletteRandomIndex].value
+		case FillBasisTypeEnum.PALETTE_LOOP:
+			const paletteLoopIndex = index % palette.length
+			return palette[paletteLoopIndex].value
 		case FillBasisTypeEnum.PIXEL:
 			// random to highlight something went wrong
 			return pixelHex || colorRandomHex()

--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-fill.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-fill.service.ts
@@ -1,6 +1,10 @@
 import { FillBasisTypeEnum, FillStyleTypeEnum } from '#app/schema/fill'
+import {
+	getCircularItemInArray,
+	getRandomItemInArray,
+	getReverseCircularItemInArray,
+} from '#app/utils/array.utils'
 import { colorRandomHex } from '#app/utils/colors'
-import { randomIndex } from '#app/utils/random.utils'
 import { type IArtboardLayerBuild } from '../../../../queries'
 
 export const canvasBuildLayerDrawFillService = ({
@@ -25,15 +29,11 @@ export const canvasBuildLayerDrawFillService = ({
 		case FillBasisTypeEnum.PALETTE_SELECTED:
 			return palette[0].value
 		case FillBasisTypeEnum.PALETTE_RANDOM:
-			const paletteRandomIndex = randomIndex(palette)
-			return palette[paletteRandomIndex].value
+			return getRandomItemInArray(palette).value
 		case FillBasisTypeEnum.PALETTE_LOOP:
-			const paletteLoopIndex = index % palette.length
-			return palette[paletteLoopIndex].value
+			return getCircularItemInArray(palette, index).value
 		case FillBasisTypeEnum.PALETTE_LOOP_REVERSE:
-			const paletteReverseLoopIndex =
-				palette.length - 1 - (index % palette.length)
-			return palette[paletteReverseLoopIndex].value
+			return getReverseCircularItemInArray(palette, index).value
 		case FillBasisTypeEnum.PIXEL:
 			// random to highlight something went wrong
 			return pixelHex || colorRandomHex()

--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-rotate.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-rotate.service.ts
@@ -1,5 +1,9 @@
 import { RotateBasisTypeEnum } from '#app/schema/rotate'
-import { randomInRange } from '#app/utils/random.utils'
+import {
+	getCircularItemInArray,
+	getRandomItemInArray,
+	getReverseCircularItemInArray,
+} from '#app/utils/array.utils'
 import { rotateToRadians } from '#app/utils/rotate'
 import { type IArtboardLayerBuild } from '../../../../queries'
 
@@ -13,11 +17,18 @@ export const canvasBuildLayerDrawRotateService = ({
 	const { rotate } = layer
 	const { basis } = rotate
 
-	if (basis === RotateBasisTypeEnum.DEFINED_RANDOM) {
-		return randomInRotates({ layer })
+	switch (basis) {
+		case RotateBasisTypeEnum.DEFINED:
+			return rotateToRadians(rotate)
+		case RotateBasisTypeEnum.VISIBLE_RANDOM:
+			return randomInRotates({ layer })
+		case RotateBasisTypeEnum.VISIBLE_LOOP:
+			return loopInRotates({ layer, index })
+		case RotateBasisTypeEnum.VISIBLE_LOOP_REVERSE:
+			return reverseLoopInRotates({ layer, index })
+		default:
+			return rotateToRadians(rotate)
 	}
-
-	return rotateToRadians(rotate)
 }
 
 const randomInRotates = ({ layer }: { layer: IArtboardLayerBuild }) => {
@@ -26,8 +37,38 @@ const randomInRotates = ({ layer }: { layer: IArtboardLayerBuild }) => {
 	// If there are no rotates or the array is empty, return 0
 	if (!rotates || !rotates.length) return 0
 
-	const randomIndex = randomInRange(0, rotates.length - 1)
-	const rotate = rotates[randomIndex]
+	const rotate = getRandomItemInArray(rotates)
+	return rotateToRadians(rotate)
+}
 
+const loopInRotates = ({
+	layer,
+	index,
+}: {
+	layer: IArtboardLayerBuild
+	index: number
+}) => {
+	const { rotates } = layer
+
+	// If there are no rotates or the array is empty, return 0
+	if (!rotates || !rotates.length) return 0
+
+	const rotate = getCircularItemInArray(rotates, index)
+	return rotateToRadians(rotate)
+}
+
+const reverseLoopInRotates = ({
+	layer,
+	index,
+}: {
+	layer: IArtboardLayerBuild
+	index: number
+}) => {
+	const { rotates } = layer
+
+	// If there are no rotates or the array is empty, return 0
+	if (!rotates || !rotates.length) return 0
+
+	const rotate = getReverseCircularItemInArray(rotates, index)
 	return rotateToRadians(rotate)
 }

--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-rotate.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-rotate.service.ts
@@ -35,7 +35,7 @@ const randomInRotates = ({ layer }: { layer: IArtboardLayerBuild }) => {
 	const { rotates } = layer
 
 	// If there are no rotates or the array is empty, return 0
-	if (!rotates || !rotates.length) return 0
+	if (!rotates?.length) return 0
 
 	const rotate = getRandomItemInArray(rotates)
 	return rotateToRadians(rotate)
@@ -51,7 +51,7 @@ const loopInRotates = ({
 	const { rotates } = layer
 
 	// If there are no rotates or the array is empty, return 0
-	if (!rotates || !rotates.length) return 0
+	if (!rotates?.length) return 0
 
 	const rotate = getCircularItemInArray(rotates, index)
 	return rotateToRadians(rotate)
@@ -67,7 +67,7 @@ const reverseLoopInRotates = ({
 	const { rotates } = layer
 
 	// If there are no rotates or the array is empty, return 0
-	if (!rotates || !rotates.length) return 0
+	if (!rotates?.length) return 0
 
 	const rotate = getReverseCircularItemInArray(rotates, index)
 	return rotateToRadians(rotate)

--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-stroke.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-stroke.service.ts
@@ -23,8 +23,11 @@ export const canvasBuildLayerDrawStrokeService = ({
 		case StrokeBasisTypeEnum.PALETTE_SELECTED:
 			return palette[0].value
 		case StrokeBasisTypeEnum.PALETTE_RANDOM:
-			const index = randomIndex(palette)
-			return palette[index].value
+			const paletteRandomIndex = randomIndex(palette)
+			return palette[paletteRandomIndex].value
+		case StrokeBasisTypeEnum.PALETTE_LOOP:
+			const paletteLoopIndex = index % palette.length
+			return palette[paletteLoopIndex].value
 		case StrokeBasisTypeEnum.PIXEL:
 			// random to highlight something went wrong
 			return pixelHex || colorRandomHex()

--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-stroke.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-stroke.service.ts
@@ -1,6 +1,10 @@
 import { StrokeBasisTypeEnum } from '#app/schema/stroke'
+import {
+	getCircularItemInArray,
+	getRandomItemInArray,
+	getReverseCircularItemInArray,
+} from '#app/utils/array.utils'
 import { colorRandomHex } from '#app/utils/colors'
-import { randomIndex } from '#app/utils/random.utils'
 import { type IArtboardLayerBuild } from '../../../../queries'
 
 export const canvasBuildLayerDrawStrokeService = ({
@@ -23,15 +27,11 @@ export const canvasBuildLayerDrawStrokeService = ({
 		case StrokeBasisTypeEnum.PALETTE_SELECTED:
 			return palette[0].value
 		case StrokeBasisTypeEnum.PALETTE_RANDOM:
-			const paletteRandomIndex = randomIndex(palette)
-			return palette[paletteRandomIndex].value
+			return getRandomItemInArray(palette).value
 		case StrokeBasisTypeEnum.PALETTE_LOOP:
-			const paletteLoopIndex = index % palette.length
-			return palette[paletteLoopIndex].value
+			return getCircularItemInArray(palette, index).value
 		case StrokeBasisTypeEnum.PALETTE_LOOP_REVERSE:
-			const paletteReverseLoopIndex =
-				palette.length - 1 - (index % palette.length)
-			return palette[paletteReverseLoopIndex].value
+			return getReverseCircularItemInArray(palette, index).value
 		case StrokeBasisTypeEnum.PIXEL:
 			// random to highlight something went wrong
 			return pixelHex || colorRandomHex()

--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-stroke.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-stroke.service.ts
@@ -28,6 +28,10 @@ export const canvasBuildLayerDrawStrokeService = ({
 		case StrokeBasisTypeEnum.PALETTE_LOOP:
 			const paletteLoopIndex = index % palette.length
 			return palette[paletteLoopIndex].value
+		case StrokeBasisTypeEnum.PALETTE_LOOP_REVERSE:
+			const paletteReverseLoopIndex =
+				palette.length - 1 - (index % palette.length)
+			return palette[paletteReverseLoopIndex].value
 		case StrokeBasisTypeEnum.PIXEL:
 			// random to highlight something went wrong
 			return pixelHex || colorRandomHex()

--- a/app/schema/fill.ts
+++ b/app/schema/fill.ts
@@ -6,6 +6,7 @@ export const FillBasisTypeEnum = {
 	RANDOM: 'random', // random hex value
 	PALETTE_SELECTED: 'palette-selected', // first palette
 	PALETTE_RANDOM: 'palette-random', // random palette
+	PALETTE_LOOP: 'palette-loop', // loop palette for each layer item
 	PIXEL: 'pixel', // pixel color
 	// add more basis types here
 } as const

--- a/app/schema/fill.ts
+++ b/app/schema/fill.ts
@@ -4,9 +4,10 @@ import { HexcodeSchema } from './colors'
 export const FillBasisTypeEnum = {
 	DEFINED: 'defined', // exact hex value
 	RANDOM: 'random', // random hex value
-	PALETTE_SELECTED: 'palette-selected', // first palette
-	PALETTE_RANDOM: 'palette-random', // random palette
-	PALETTE_LOOP: 'palette-loop', // loop palette for each layer item
+	PALETTE_SELECTED: 'palette-selected', // first palette in array
+	PALETTE_RANDOM: 'palette-random', // random palette in array
+	PALETTE_LOOP: 'palette-loop', // loop palette array by index
+	PALETTE_LOOP_REVERSE: 'palette-loop-reverse', // loop reversed palette array by index
 	PIXEL: 'pixel', // pixel color
 	// add more basis types here
 } as const

--- a/app/schema/rotate.ts
+++ b/app/schema/rotate.ts
@@ -12,7 +12,7 @@ export type rotateArrayBasisTypeEnum = ObjectValues<
 	typeof RotateArrayBasisTypeEnum
 >
 
-export const RotateBasisTypeEnum = {
+export const RotateIndividualBasisTypeEnum = {
 	DEFINED: 'defined', // exact rotation value
 	RANDOM: 'random', // random rotation value
 	N: 'N', // 0 degrees
@@ -23,6 +23,13 @@ export const RotateBasisTypeEnum = {
 	SW: 'SW', // 225 degrees
 	W: 'W', // 270 degrees
 	NW: 'NW', // 315 degrees
+} as const
+export type rotateIndividualBasisTypeEnum = ObjectValues<
+	typeof RotateIndividualBasisTypeEnum
+>
+
+export const RotateBasisTypeEnum = {
+	...RotateIndividualBasisTypeEnum,
 	...RotateArrayBasisTypeEnum,
 	// add more basis types here
 } as const

--- a/app/schema/rotate.ts
+++ b/app/schema/rotate.ts
@@ -1,9 +1,20 @@
 import { z } from 'zod'
 
+type ObjectValues<T> = T[keyof T]
+
+// use this for determining if build should iterate through rotates array
+export const RotateArrayBasisTypeEnum = {
+	VISIBLE_RANDOM: 'visible-random',
+	VISIBLE_LOOP: 'visible-loop',
+	VISIBLE_LOOP_REVERSE: 'visible-loop-reverse',
+} as const
+export type rotateArrayBasisTypeEnum = ObjectValues<
+	typeof RotateArrayBasisTypeEnum
+>
+
 export const RotateBasisTypeEnum = {
 	DEFINED: 'defined', // exact rotation value
 	RANDOM: 'random', // random rotation value
-	DEFINED_RANDOM: 'defined-random', // random visible rotation values
 	N: 'N', // 0 degrees
 	NE: 'NE', // 45 degrees
 	E: 'E', // 90 degrees
@@ -12,9 +23,9 @@ export const RotateBasisTypeEnum = {
 	SW: 'SW', // 225 degrees
 	W: 'W', // 270 degrees
 	NW: 'NW', // 315 degrees
+	...RotateArrayBasisTypeEnum,
 	// add more basis types here
 } as const
-type ObjectValues<T> = T[keyof T]
 export type rotateBasisTypeEnum = ObjectValues<typeof RotateBasisTypeEnum>
 
 const RotateBasisSchema = z.nativeEnum(RotateBasisTypeEnum)

--- a/app/schema/stroke.ts
+++ b/app/schema/stroke.ts
@@ -6,6 +6,7 @@ export const StrokeBasisTypeEnum = {
 	RANDOM: 'random', // random hex value
 	PALETTE_SELECTED: 'palette-selected', // first palette
 	PALETTE_RANDOM: 'palette-random', // random palette
+	PALETTE_LOOP: 'palette-loop', // loop palette for each layer item
 	PIXEL: 'pixel', // pixel color
 	// add more basis types here
 } as const

--- a/app/schema/stroke.ts
+++ b/app/schema/stroke.ts
@@ -4,9 +4,10 @@ import { HexcodeSchema } from './colors'
 export const StrokeBasisTypeEnum = {
 	DEFINED: 'defined', // exact hex value
 	RANDOM: 'random', // random hex value
-	PALETTE_SELECTED: 'palette-selected', // first palette
-	PALETTE_RANDOM: 'palette-random', // random palette
-	PALETTE_LOOP: 'palette-loop', // loop palette for each layer item
+	PALETTE_SELECTED: 'palette-selected', // first palette in array
+	PALETTE_RANDOM: 'palette-random', // random palette in array
+	PALETTE_LOOP: 'palette-loop', // loop palette array by index
+	PALETTE_LOOP_REVERSE: 'palette-loop-reverse', // loop reversed palette array by index
 	PIXEL: 'pixel', // pixel color
 	// add more basis types here
 } as const

--- a/app/utils/array.utils.ts
+++ b/app/utils/array.utils.ts
@@ -1,0 +1,21 @@
+// Function to get an item from an array in a circular manner.
+
+import { randomIndex } from './random.utils'
+
+// If the index is out of bounds, it wraps around the array.
+export const getCircularItemInArray = <T>(array: T[], index: number): T => {
+	return array[index % array.length]
+}
+
+// Function to get an item from an array in a reverse circular manner.
+// It starts from the end of the array and wraps around in reverse order if the index is out of bounds.
+export const getReverseCircularItemInArray = <T>(
+	array: T[],
+	index: number,
+): T => {
+	return array[array.length - 1 - (index % array.length)]
+}
+
+export const getRandomItemInArray = <T>(array: T[]): T => {
+	return array[randomIndex(array)]
+}

--- a/app/utils/rotate.ts
+++ b/app/utils/rotate.ts
@@ -1,13 +1,22 @@
 import { type IRotate } from '#app/models/rotate.server'
-import { RotateBasisTypeEnum } from '#app/schema/rotate'
+import {
+	RotateArrayBasisTypeEnum,
+	RotateBasisTypeEnum,
+	type rotateBasisTypeEnum,
+} from '#app/schema/rotate'
 
 // 🥧
 const PI = Math.PI
 
-export const filterDefinedRotates = (rotates: IRotate[]): IRotate[] => {
+export const filterNonArrayRotates = (rotates: IRotate[]): IRotate[] => {
 	return rotates.filter(
-		rotate => rotate.basis !== RotateBasisTypeEnum.DEFINED_RANDOM,
+		rotate => !isArrayRotateBasisType(rotate.basis as rotateBasisTypeEnum),
 	)
+}
+
+// Function to check if a basis is a visible type
+export const isArrayRotateBasisType = (basis: rotateBasisTypeEnum): boolean => {
+	return Object.values(RotateArrayBasisTypeEnum).includes(basis)
 }
 
 export const rotateToRadians = (rotate: IRotate): number => {


### PR DESCRIPTION
allow for circular looping for palette and rotate arrays (and reverse)
bug with bottom panel popovers when select opens led to dialog being added for some at the bottom
rotate is getting to have a lot so might want to rethink how to organize individual designs vs array options