### PR TITLE
FIX: line width affects size

### DIFF
--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-line.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-line.service.ts
@@ -1,14 +1,6 @@
-import { type ISize } from '#app/models/size.server'
-import { LineBasisTypeEnum, LineFormatTypeEnum } from '#app/schema/line'
-import { SizeBasisTypeEnum } from '#app/schema/size'
-import {
-	type IArtboardLayerContainerBuild,
-	type IArtboardLayerBuild,
-} from '../../../../queries'
-
-// FYI line width affects the size of the template
-// come back to this when grid is ready
-// for making sure my adjustments are more precise
+import { LineFormatTypeEnum } from '#app/schema/line'
+import { linePercentToPixel } from '#app/utils/line'
+import { type IArtboardLayerBuild } from '../../../../queries'
 
 export const canvasBuildLayerDrawLineService = ({
 	layer,
@@ -18,52 +10,11 @@ export const canvasBuildLayerDrawLineService = ({
 	index: number
 }) => {
 	const { line, size, container } = layer
-	const { width, basis, format } = line
+	const { width, format } = line
 
 	if (format === LineFormatTypeEnum.PERCENT) {
-		const linePercent = width / 100
-
-		switch (basis) {
-			case LineBasisTypeEnum.SIZE:
-				const sizeValue = sizePercentToPixel({ size, container })
-				return sizeValue * linePercent
-			case LineBasisTypeEnum.WIDTH:
-				return container.width * linePercent
-			case LineBasisTypeEnum.HEIGHT:
-				return container.height * linePercent
-			case LineBasisTypeEnum.CANVAS_WIDTH:
-				return container.canvas.width * linePercent
-			case LineBasisTypeEnum.CANVAS_HEIGHT:
-				return container.canvas.height * linePercent
-			default:
-				return 0
-		}
+		return linePercentToPixel({ line, size, container })
 	}
 
 	return width
-}
-
-const sizePercentToPixel = ({
-	size,
-	container,
-}: {
-	size: ISize
-	container: IArtboardLayerContainerBuild
-}) => {
-	const { basis, value } = size
-	const sizePercent = value / 100
-
-	switch (basis) {
-		case SizeBasisTypeEnum.WIDTH:
-			return container.width * sizePercent
-		case SizeBasisTypeEnum.HEIGHT:
-			return container.height * sizePercent
-		case SizeBasisTypeEnum.CANVAS_WIDTH:
-			return container.canvas.width * sizePercent
-		case SizeBasisTypeEnum.CANVAS_HEIGHT:
-			return container.canvas.height * sizePercent
-		default:
-			// something went wrong
-			return 0
-	}
 }

--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-size.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/build/build-layer-draw-size.service.ts
@@ -19,7 +19,6 @@ export const canvasBuildLayerDrawSizeService = ({
 
 	// const adjLineSize = linePercentToPixel({ line, size, container })
 	const adjLineSize = getAdjustedLineSize({ line, size, container })
-	console.log(adjLineSize)
 
 	if (format === SizeFormatTypeEnum.PERCENT) {
 		return sizePercentToPixel({ size, container }) - adjLineSize

--- a/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/draw/templates/draw-layer-item-template-triangle.service.ts
+++ b/app/routes/sketch+/artboards+/$slug_+/services/canvas/layer/draw/templates/draw-layer-item-template-triangle.service.ts
@@ -39,6 +39,8 @@ const drawLines = ({
 	inset: number
 	points: number
 }) => {
+	// ctx.lineJoin = 'round'
+	// ctx.miterLimit = 1
 	// top middle
 	ctx.lineTo(0, 0 - radius)
 	ctx.rotate(Math.PI / points)

--- a/app/utils/line.ts
+++ b/app/utils/line.ts
@@ -1,0 +1,54 @@
+import { type ILine } from '#app/models/line.server'
+import { type ISize } from '#app/models/size.server'
+import { type IArtboardLayerContainerBuild } from '#app/routes/sketch+/artboards+/$slug_+/queries'
+import { LineBasisTypeEnum } from '#app/schema/line'
+import { degreesToRadians } from './rotate'
+import { sizePercentToPixel } from './size'
+
+export const linePercentToPixel = ({
+	line,
+	size,
+	container,
+}: {
+	line: ILine
+	size: ISize
+	container: IArtboardLayerContainerBuild
+}) => {
+	const { width, basis } = line
+	const linePercent = width / 100
+
+	switch (basis) {
+		case LineBasisTypeEnum.SIZE:
+			const sizeValue = sizePercentToPixel({ size, container })
+			return sizeValue * linePercent
+		case LineBasisTypeEnum.WIDTH:
+			return container.width * linePercent
+		case LineBasisTypeEnum.HEIGHT:
+			return container.height * linePercent
+		case LineBasisTypeEnum.CANVAS_WIDTH:
+			return container.canvas.width * linePercent
+		case LineBasisTypeEnum.CANVAS_HEIGHT:
+			return container.canvas.height * linePercent
+		default:
+			return 0
+	}
+}
+
+// the miter extends beyond the line by the stroke width
+// to account for the miter join, we need to calculate the stick out length
+// so we can reduce the size of the line by this amount
+export const calculateMiterStickOutLength = ({
+	lineWidth,
+	angle,
+}: {
+	lineWidth: number
+	angle: number
+}) => {
+	// convert the base angle to radians
+	const baseAngleRadians = degreesToRadians(angle / 2)
+
+	// calculate the miter length
+	const miterStickOutLength = lineWidth / 2 / Math.cos(baseAngleRadians)
+
+	return miterStickOutLength
+}

--- a/app/utils/rotate.ts
+++ b/app/utils/rotate.ts
@@ -47,7 +47,7 @@ export const rotateToRadians = (rotate: IRotate): number => {
 	}
 }
 
-const degreesToRadians = (degrees: number) => degrees * (PI / 180)
+export const degreesToRadians = (degrees: number) => degrees * (PI / 180)
 
 const rotateRandom = (): number => {
 	return Math.random() * PI * 2

--- a/app/utils/size.ts
+++ b/app/utils/size.ts
@@ -1,0 +1,28 @@
+import { type ISize } from '#app/models/size.server'
+import { type IArtboardLayerContainerBuild } from '#app/routes/sketch+/artboards+/$slug_+/queries'
+import { SizeBasisTypeEnum } from '#app/schema/size'
+
+export const sizePercentToPixel = ({
+	size,
+	container,
+}: {
+	size: ISize
+	container: IArtboardLayerContainerBuild
+}) => {
+	const { basis, value } = size
+	const sizePercent = value / 100
+
+	switch (basis) {
+		case SizeBasisTypeEnum.WIDTH:
+			return container.width * sizePercent
+		case SizeBasisTypeEnum.HEIGHT:
+			return container.height * sizePercent
+		case SizeBasisTypeEnum.CANVAS_WIDTH:
+			return container.canvas.width * sizePercent
+		case SizeBasisTypeEnum.CANVAS_HEIGHT:
+			return container.canvas.height * sizePercent
+		default:
+			// something went wrong
+			return 0
+	}
+}


### PR DESCRIPTION
- miter length is spilling side length of triangle over
- using "simple" trigonometry (with help from ChatGPT) I am calculating the horizontal length that sticks out beyond the where the lines join + the line width
- subtracting that from the calculated size
- looks good